### PR TITLE
fix pyproject package definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Extract files from UBI and UBIFS images."
 authors = ["ONEKEY <support@onekey.com>", "Jason Pruitt <jrspruitt@gmail.com>"]
 license = "GNU GPL"
 readme = "README.md"
-packages = [{include = "ubi_reader"}]
+packages = [{include = "ubireader"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
PyPi release [failed](https://github.com/onekey-sec/ubi_reader/actions/runs/4983254045/jobs/8920037969) because of a small typo in pyproject. My bad :)
