### PR TITLE
bump version to 0.8.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubi-reader"
-version = "0.8.6"
+version = "0.8.7"
 description = "Extract files from UBI and UBIFS images."
 authors = ["ONEKEY <support@onekey.com>", "Jason Pruitt <jrspruitt@gmail.com>"]
 license = "GNU GPL"


### PR DESCRIPTION
Even if v0.8.6 was deleted from PyPi, we can't re-upload it under that name so we need to bump version.