### PR TITLE
fix for KeyError in decrypt_filenames

### DIFF
--- a/ubireader/ubifs/decrypt.py
+++ b/ubireader/ubifs/decrypt.py
@@ -70,7 +70,7 @@ def datablock_decrypt(block_key: bytes, block_iv: bytes, block_data: bytes):
 def decrypt_filenames(ubifs, inodes):
     if ubifs.master_key is None:
         for inode in inodes.values():
-             for dent in inode['dent']:
+            for dent in inode.get('dent', []):
                 dent.name = dent.raw_name.decode()
         return
     try:


### PR DESCRIPTION
Somehow ubi-reader in version 0.8.11 always stops with a cryptic error `extract_files Error: 'dent'` when trying to unpack a ubi filesystem with ubireader_extract_files. It seems this is caused by a KeyError in decrypt_filenames where not every inode contains a "dent" entry.