### PR TITLE
Add type hints to the codebase

### DIFF
--- a/ubireader/debug.py
+++ b/ubireader/debug.py
@@ -17,23 +17,36 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
 import sys
 import traceback
+from typing import Literal, NoReturn, Protocol, overload
 from ubireader import settings
 
-def log(obj, message):
+class _Obj(Protocol):
+    __name__: str
+
+def log(obj: _Obj, message: str) -> None:
     if settings.logging_on or settings.logging_on_verbose:
         print('{} {}'.format(obj.__name__, message))
 
-def verbose_log(obj, message):
+def verbose_log(obj: _Obj, message: str) -> None:
     if settings.logging_on_verbose:
         log(obj, message)
 
-def verbose_display(displayable_obj):
+class _Displayable(Protocol):
+    def display(self, tab: str) -> str: ...
+
+def verbose_display(displayable_obj: _Displayable) -> None:
     if settings.logging_on_verbose:
         print(displayable_obj.display('\t'))
 
-def error(obj, level, message):
+@overload
+def error(obj: _Obj, level: Literal['fatal', 'Fatal'], message: str) -> NoReturn: ...
+@overload
+def error(obj: _Obj, level: str, message: str) -> None: ...
+
+def error(obj: _Obj, level: str, message: str) -> None:
     if settings.error_action == 'exit':
         print('{} {}: {}'.format(obj.__name__, level, message))
         if settings.fatal_traceback:

--- a/ubireader/ubi/__init__.py
+++ b/ubireader/ubi/__init__.py
@@ -17,11 +17,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from ubireader.debug import error
 from ubireader.ubi.block import sort, extract_blocks
 from ubireader.ubi import display
 from ubireader.ubi.image import description as image
 from ubireader.ubi.block import layout, rm_old_blocks
+
+if TYPE_CHECKING:
+    from ubireader.ubi_io import ubi_file as UbiFile
+    from ubireader.ubi.block import description as Block
+    from ubireader.ubi.image import description as Image
 
 class ubi_base(object):
     """UBI Base object
@@ -39,7 +46,7 @@ class ubi_base(object):
     Dict:blocks        -- Dict keyed by PEB number of all blocks.
     """
 
-    def __init__(self, ubi_file):
+    def __init__(self, ubi_file: UbiFile) -> None:
         self.__name__ = 'UBI'
         self._file = ubi_file
         self._first_peb_num = 0
@@ -54,7 +61,7 @@ class ubi_base(object):
         self._leb_size = self.file.block_size - arbitrary_block.ec_hdr.data_offset
 
 
-    def _get_file(self):
+    def _get_file(self) -> UbiFile:
         """UBI File object
 
         Returns:
@@ -64,7 +71,7 @@ class ubi_base(object):
     file = property(_get_file)
 
 
-    def _get_block_count(self):
+    def _get_block_count(self) -> int:
         """Total amount of UBI blocks in file.
 
         Returns:
@@ -74,9 +81,9 @@ class ubi_base(object):
     block_count = property(_get_block_count)
 
 
-    def _set_first_peb_num(self, i):
+    def _set_first_peb_num(self, i: int) -> None:
         self._first_peb_num = i
-    def _get_first_peb_num(self):
+    def _get_first_peb_num(self) -> int:
         """First Physical Erase Block with UBI data
         
         Returns:
@@ -86,7 +93,7 @@ class ubi_base(object):
     first_peb_num = property(_get_first_peb_num, _set_first_peb_num)
 
 
-    def _get_leb_size(self):
+    def _get_leb_size(self) -> int:
         """LEB size of UBI blocks in file.
 
         Returns:
@@ -96,7 +103,7 @@ class ubi_base(object):
     leb_size = property(_get_leb_size)
 
 
-    def _get_peb_size(self):
+    def _get_peb_size(self) -> int:
         """PEB size of UBI blocks in file.
 
         Returns:
@@ -106,7 +113,7 @@ class ubi_base(object):
     peb_size = property(_get_peb_size)
 
 
-    def _get_min_io_size(self):
+    def _get_min_io_size(self) -> int:
         """Min I/O Size
 
         Returns:
@@ -116,7 +123,7 @@ class ubi_base(object):
     min_io_size = property(_get_min_io_size)
 
 
-    def _get_blocks(self):
+    def _get_blocks(self) -> dict[int, Block]:
         """Main Dict of UBI Blocks
 
         Passed around for lists of indexes to be made or to be returned
@@ -142,7 +149,7 @@ class ubi(ubi_base):
     List:unknown_blocks_list  -- List of blocks with unknown types. *
     """
 
-    def __init__(self, ubi_file):
+    def __init__(self, ubi_file: UbiFile) -> None:
         super(ubi, self).__init__(ubi_file)
 
         layout_list, data_list, int_vol_list, unknown_list = sort.by_type(self.blocks)
@@ -161,12 +168,12 @@ class ubi(ubi_base):
 
         layout_infos = layout.associate_blocks(self.blocks, layout_pairs)
 
-        self._images = []
+        self._images: list[Image] = []
         for i in range(0, len(layout_infos)):
             self._images.append(image(self.blocks, layout_infos[i]))
 
 
-    def _get_images(self):
+    def _get_images(self) -> list[Image]:
         """Get UBI images.
 
         Returns:
@@ -176,7 +183,7 @@ class ubi(ubi_base):
     images = property(_get_images)
 
 
-    def _get_data_blocks_list(self):
+    def _get_data_blocks_list(self) -> list[int]:
         """Get all UBI blocks found in file that are data blocks.
 
         Returns:
@@ -186,7 +193,7 @@ class ubi(ubi_base):
     data_blocks_list = property(_get_data_blocks_list)
 
 
-    def _get_layout_blocks_list(self):
+    def _get_layout_blocks_list(self) -> list[int]:
         """Get all UBI blocks found in file that are layout volume blocks.
 
         Returns:
@@ -196,7 +203,7 @@ class ubi(ubi_base):
     layout_blocks_list = property(_get_layout_blocks_list)
 
 
-    def _get_int_vol_blocks_list(self):
+    def _get_int_vol_blocks_list(self) -> list[int]:
         """Get all UBI blocks found in file that are internal volume blocks.
 
         Returns:
@@ -208,7 +215,7 @@ class ubi(ubi_base):
     int_vol_blocks_list = property(_get_int_vol_blocks_list)
 
 
-    def _get_unknown_blocks_list(self):
+    def _get_unknown_blocks_list(self) -> list[int]:
         """Get all UBI blocks found in file of unknown type..
 
         Returns:
@@ -217,7 +224,7 @@ class ubi(ubi_base):
         return self._unknown_blocks_list
     unknown_blocks_list = property(_get_unknown_blocks_list)
     
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         """Print information about this object.
         
         Argument:

--- a/ubireader/ubi/block/sort.py
+++ b/ubireader/ubi/block/sort.py
@@ -17,9 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING, Literal
 from ubireader import settings
 
-def by_image_seq(blocks, image_seq):
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from ubireader.ubi.block import description as Block
+
+def by_image_seq(blocks: Mapping[int, Block], image_seq: int) -> list[int]:
     """Filter blocks to return only those associated with the provided image_seq number.
        If uboot_fix is set, associate blocks with an image_seq of 0 also.
 
@@ -36,7 +42,7 @@ def by_image_seq(blocks, image_seq):
     else:
         return list(filter(lambda block: blocks[block].ec_hdr.image_seq == image_seq, blocks))
 
-def by_leb(blocks):
+def by_leb(blocks: Mapping[int, Block]) -> list[Literal['x'] | int]:
     """Sort blocks by Logical Erase Block number.
     
     Arguments:
@@ -46,7 +52,7 @@ def by_leb(blocks):
     List              -- Indexes of blocks sorted by LEB.
     """ 
     slist_len = len(blocks)
-    slist = ['x'] * slist_len
+    slist: list[Literal['x'] | int] = ['x'] * slist_len
 
     for block in blocks:
         if blocks[block].leb_num >= slist_len:
@@ -59,7 +65,7 @@ def by_leb(blocks):
     return slist
 
 
-def by_vol_id(blocks, slist=None):
+def by_vol_id(blocks: Mapping[int, Block], slist: list[int] | None = None) -> dict[int, list[int]]:
     """Sort blocks by volume id
 
     Arguments:
@@ -70,7 +76,7 @@ def by_vol_id(blocks, slist=None):
     Dict -- blocks grouped in lists with dict key as volume id.
     """
 
-    vol_blocks = {}
+    vol_blocks: dict[int, list[int]] = {}
 
     # sort block by volume
     # not reliable with multiple partitions (fifo)
@@ -88,7 +94,7 @@ def by_vol_id(blocks, slist=None):
 
     return vol_blocks
 
-def by_type(blocks, slist=None):
+def by_type(blocks: Mapping[int, Block], slist: list[int] | None = None) -> tuple[list[int], list[int], list[int], list[int]]:
     """Sort blocks into layout, internal volume, data or unknown
 
     Arguments:
@@ -106,10 +112,10 @@ def by_type(blocks, slist=None):
                     of crc in ed_hdr or vid_hdr.
     """
 
-    layout = []
-    data = []
-    int_vol = []
-    unknown = []
+    layout: list[int] = []
+    data: list[int] = []
+    int_vol: list[int] = []
+    unknown: list[int] = []
     
     for i in blocks:
         if slist and i not in slist:

--- a/ubireader/ubi/display.py
+++ b/ubireader/ubi/display.py
@@ -17,10 +17,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from ubireader import settings
 from ubireader.ubi.defines import PRINT_COMPAT_LIST, PRINT_VOL_TYPE_LIST, UBI_VTBL_AUTORESIZE_FLG
 
-def ubi(ubi, tab=''):
+if TYPE_CHECKING:
+    from ubireader.ubi import ubi as Ubi
+    from ubireader.ubi.block import description as Block
+    from ubireader.ubi.headers import ec_hdr as EcHdr, vid_hdr as VidHdr, _vtbl_rec as VtblRec
+    from ubireader.ubi.image import description as Image
+    from ubireader.ubi.volume import description as Volume
+
+def ubi(ubi: Ubi, tab: str = '') -> str:
     buf = '%sUBI File\n' % (tab) 
     buf += '%s---------------------\n' % (tab)
     buf += '\t%sMin I/O: %s\n' % (tab, ubi.min_io_size)
@@ -35,7 +44,7 @@ def ubi(ubi, tab=''):
     return buf
 
 
-def image(image, tab=''):
+def image(image: Image, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, image)
     buf += '%s---------------------\n' % (tab)
     buf += '\t%sImage Sequence Num: %s\n' % (tab, image.image_seq)
@@ -45,7 +54,7 @@ def image(image, tab=''):
     return buf
 
 
-def volume(volume, tab=''):
+def volume(volume: Volume, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, volume)
     buf += '%s---------------------\n' % (tab)
     buf += '\t%sVol ID: %s\n' % (tab, volume.vol_id)
@@ -61,7 +70,7 @@ def volume(volume, tab=''):
     return buf
 
 
-def block(block, tab='\t'):
+def block(block: Block, tab: str = '\t') -> str:
     buf = '%s%s\n' % (tab, block)
     buf += '%s---------------------\n' % (tab)
     buf += '\t%sFile Offset: %s\n' %  (tab, block.file_offset)
@@ -95,7 +104,7 @@ def block(block, tab='\t'):
     return buf
 
 
-def ec_hdr(ec_hdr, tab=''):
+def ec_hdr(ec_hdr: EcHdr, tab: str = '') -> str:
     buf = ''
     for key, value in ec_hdr:
         if key == 'errors':
@@ -108,7 +117,7 @@ def ec_hdr(ec_hdr, tab=''):
     return buf
 
 
-def vid_hdr(vid_hdr, tab=''):
+def vid_hdr(vid_hdr: VidHdr, tab: str = '') -> str:
     buf = ''
     for key, value in vid_hdr:
         if key == 'errors':
@@ -133,7 +142,7 @@ def vid_hdr(vid_hdr, tab=''):
     return buf
 
 
-def vol_rec(vol_rec, tab=''):
+def vol_rec(vol_rec: VtblRec, tab: str = '') -> str:
     buf = ''
     for key, value in vol_rec:
         if key == 'errors':

--- a/ubireader/ubi/image.py
+++ b/ubireader/ubi/image.py
@@ -17,13 +17,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from ubireader.debug import log
 from ubireader.ubi import display
 from ubireader.ubi.volume import get_volumes
 from ubireader.ubi.block import get_blocks_in_list
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from ubireader.ubi.block import description as Block
+    from ubireader.ubi.block.layout import _LayoutInfo
+    from ubireader.ubi.volume import description as Volume
+
 class description(object):
-    def __init__(self, blocks, layout_info):
+    def __init__(self, blocks: dict[int, Block], layout_info: _LayoutInfo) -> None:
         self._image_seq = blocks[layout_info[0]].ec_hdr.image_seq
         self.vid_hdr_offset = blocks[layout_info[0]].ec_hdr.vid_hdr_offset
         self.version = blocks[layout_info[0]].ec_hdr.version
@@ -33,28 +41,28 @@ class description(object):
         self._volumes = get_volumes(blocks, layout_info)
         log(description, 'Created Image: %s, Volume Cnt: %s' % (self.image_seq, len(self.volumes)))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Image: %s' % (self.image_seq)
 
 
-    def get_blocks(self, blocks):
+    def get_blocks(self, blocks: Mapping[int, Block]) -> dict[int, Block]:
         return get_blocks_in_list(blocks, self._block_list)
 
 
-    def _get_peb_range(self):
+    def _get_peb_range(self) -> list[int]:
         return [self._start_peb, self._end_peb]
     peb_range = property(_get_peb_range)
 
 
-    def _get_image_seq(self):
+    def _get_image_seq(self) -> int:
         return self._image_seq
     image_seq = property(_get_image_seq)
 
 
-    def _get_volumes(self):
+    def _get_volumes(self) -> dict[str, Volume]:
         return self._volumes
     volumes = property(_get_volumes)
 
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.image(self, tab)

--- a/ubireader/ubifs/__init__.py
+++ b/ubireader/ubifs/__init__.py
@@ -17,10 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from ubireader.debug import error, log, verbose_display
 from ubireader.ubifs.defines import *
 from ubireader.ubifs import nodes, display
-from typing import Optional
+
+if TYPE_CHECKING:
+    from ubireader.ubi_io import ubi_file as UbiFile, leb_virtual_file as LebVirtualFile
 
 class ubifs():
     """UBIFS object
@@ -36,7 +40,7 @@ class ubifs():
     Obj:mst_node       -- Master Node of UBIFS image LEB1
     Obj:mst_node2      -- Master Node 2 of UBIFS image LEB2
     """
-    def __init__(self, ubifs_file, master_key: Optional[bytes] = None):
+    def __init__(self, ubifs_file: UbiFile | LebVirtualFile, master_key: bytes | None = None) -> None:
         self.__name__ = 'UBIFS'
         self._file = ubifs_file
         self.master_key = master_key
@@ -59,7 +63,7 @@ class ubifs():
         except Exception as e:
             error(self, 'Fatal', 'Super block error: %s' % e)
 
-        self._mst_nodes = [None, None]
+        self._mst_nodes: list[nodes.mst_node | None] = [None, None]
         for i in range(0, 2):
             try:
                 mst_offset = self.leb_size * (UBIFS_MST_LNUM + i) 
@@ -88,12 +92,12 @@ class ubifs():
             log(self , 'Swapping Master Nodes due to bad first node.')
 
 
-    def _get_file(self):
+    def _get_file(self) -> UbiFile | LebVirtualFile:
         return self._file
     file = property(_get_file)
 
 
-    def _get_superblock(self):
+    def _get_superblock(self) -> nodes.sb_node:
         """ Superblock Node Object
 
         Returns:
@@ -103,7 +107,7 @@ class ubifs():
     superblock_node = property(_get_superblock)
 
 
-    def _get_master_node(self):
+    def _get_master_node(self) -> nodes.mst_node | None:
         """Master Node Object
 
         Returns:
@@ -113,7 +117,7 @@ class ubifs():
     master_node = property(_get_master_node)
 
 
-    def _get_master_node2(self):
+    def _get_master_node2(self) -> nodes.mst_node | None:
         """Master Node Object 2
 
         Returns:
@@ -123,7 +127,7 @@ class ubifs():
     master_node2 = property(_get_master_node2)
 
 
-    def _get_leb_size(self):
+    def _get_leb_size(self) -> int:
         """LEB size of UBI blocks in file.
 
         Returns:
@@ -133,7 +137,7 @@ class ubifs():
     leb_size = property(_get_leb_size)
 
 
-    def _get_min_io_size(self):
+    def _get_min_io_size(self) -> int:
         """Min I/O Size
 
         Returns:
@@ -142,7 +146,7 @@ class ubifs():
         return self._min_io_size
     min_io_size = property(_get_min_io_size)
     
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         """Print information about this object.
         
         Argument:

--- a/ubireader/ubifs/display.py
+++ b/ubireader/ubifs/display.py
@@ -17,16 +17,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from ubireader.ubifs.defines import PRINT_UBIFS_FLGS, PRINT_UBIFS_MST
 
-def ubifs(ubifs, tab=''):
+if TYPE_CHECKING:
+    from ubireader.ubifs import ubifs as Ubifs
+    from ubireader.ubifs import nodes
+
+def ubifs(ubifs: Ubifs, tab: str = '') -> str:
     buf = '%sUBIFS Image\n' % (tab)
     buf += '%s---------------------\n' % (tab)
     buf += '%sMin I/O: %s\n' % (tab, ubifs.min_io_size)
     buf += '%sLEB Size: %s\n' % (tab, ubifs.leb_size)
     return buf
 
-def common_hdr(chdr, tab=''):
+def common_hdr(chdr: nodes.common_hdr, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, chdr)
     buf += '%s---------------------\n' % (tab)
     tab += '\t'
@@ -41,7 +47,7 @@ def common_hdr(chdr, tab=''):
             buf += '%s%s: %r\n' % (tab, key, value)
     return buf
 
-def sb_node(node, tab=''):
+def sb_node(node: nodes.sb_node, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%sFile offset: %s\n' % (tab, node.file_offset)
     buf += '%s---------------------\n' % (tab)
@@ -69,7 +75,7 @@ def sb_node(node, tab=''):
     return buf
 
 
-def mst_node(node, tab=''):
+def mst_node(node: nodes.mst_node, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%sFile offset: %s\n' % (tab, node.file_offset)
     buf += '%s---------------------\n' % (tab)
@@ -94,7 +100,7 @@ def mst_node(node, tab=''):
     return buf
 
 
-def dent_node(node, tab=''):
+def dent_node(node: nodes.dent_node, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%s---------------------\n' % (tab)
     tab += '\t'
@@ -108,7 +114,7 @@ def dent_node(node, tab=''):
     return buf
 
 
-def data_node(node, tab=''):
+def data_node(node: nodes.data_node, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%s---------------------\n' % (tab)
     tab += '\t'
@@ -122,7 +128,7 @@ def data_node(node, tab=''):
     return buf
 
 
-def idx_node(node, tab=''):
+def idx_node(node: nodes.idx_node, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%s---------------------\n' % (tab)
     tab += '\t'
@@ -136,7 +142,7 @@ def idx_node(node, tab=''):
     return buf
 
 
-def ino_node(node, tab=''):
+def ino_node(node: nodes.ino_node, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%s---------------------\n' % (tab)
     tab += '\t'
@@ -150,7 +156,7 @@ def ino_node(node, tab=''):
     return buf
 
 
-def branch(node, tab=''):
+def branch(node: nodes.branch, tab: str = '') -> str:
     buf = '%s%s\n' % (tab, node)
     buf += '%s---------------------\n' % (tab)
     tab += '\t'

--- a/ubireader/ubifs/nodes.py
+++ b/ubireader/ubifs/nodes.py
@@ -17,9 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from typing import TYPE_CHECKING, Any
 from ubireader.ubifs.misc import parse_key
 from ubireader.ubifs.defines import *
 from ubireader.ubifs import display
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from ubireader.ubifs.misc import ParsedKey
 
 class common_hdr(object):
     """Get common header at given LEB number + offset.
@@ -29,7 +35,17 @@ class common_hdr(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf):
+    errors: list[str]
+
+    magic: int
+    crc: int
+    sqnum: int
+    len: int
+    node_type: int
+    group_type: int
+    padding: bytes
+
+    def __init__(self, buf: bytes) -> None:
 
         fields = dict(list(zip(UBIFS_COMMON_HDR_FIELDS, struct.unpack(UBIFS_COMMON_HDR_FORMAT, buf))))
         for key in fields:
@@ -37,15 +53,15 @@ class common_hdr(object):
 
         setattr(self, 'errors', [])
         
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Common Header'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.common_hdr(self, tab)
 
 
@@ -57,7 +73,32 @@ class ino_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf):
+    data: bytes
+    errors: list[str]
+
+    key: ParsedKey
+    creat_sqnum: int
+    size: int
+    atime_sec: int
+    ctime_sec: int
+    mtime_sec: int
+    atime_nsec: int
+    ctime_nsec: int
+    mtime_nsec: int
+    nlink: int
+    uid: int
+    gid: int
+    mode: int
+    flags: int
+    data_len: int
+    xattr_cnt: int
+    xattr_size: int
+    padding1: bytes
+    xattr_names: int
+    compr_type: int
+    padding2: bytes
+
+    def __init__(self, buf: bytes) -> None:
 
         fields = dict(list(zip(UBIFS_INO_NODE_FIELDS, struct.unpack(UBIFS_INO_NODE_FORMAT, buf[0:UBIFS_INO_NODE_SZ]))))
         for key in fields:
@@ -69,15 +110,15 @@ class ino_node(object):
         setattr(self, 'data', buf[UBIFS_INO_NODE_SZ:])
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Ino Node'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.ino_node(self, tab)
 
 class xent_node(object):
@@ -88,7 +129,17 @@ class xent_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf):
+    name: str
+    error: list[str]
+
+    key: ParsedKey
+    inum: int
+    padding1: int
+    type: int
+    nlen: int
+    cookie: int
+
+    def __init__(self, buf: bytes) -> None:
         fields = dict(zip(UBIFS_XENT_NODE_FIELDS, struct.unpack(UBIFS_XENT_NODE_FORMAT, buf[0:UBIFS_XENT_NODE_SZ])))
         for key in fields:
             if key == 'key':
@@ -106,7 +157,7 @@ class xent_node(object):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.dent_node(self, tab)
 
 class dent_node(object):
@@ -117,7 +168,18 @@ class dent_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf):
+    raw_name: bytes
+    name: str
+    errors: list[str]
+
+    key: ParsedKey
+    inum: int
+    padding1: int
+    type: int
+    nlen: int
+    cookie: int
+
+    def __init__(self, buf: bytes) -> None:
         fields = dict(list(zip(UBIFS_DENT_NODE_FIELDS, struct.unpack(UBIFS_DENT_NODE_FORMAT, buf[0:UBIFS_DENT_NODE_SZ]))))
         for key in fields:
             if key == 'key':
@@ -128,15 +190,15 @@ class dent_node(object):
         setattr(self, 'name', "")
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Directory Entry Node'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.dent_node(self, tab)
 
 
@@ -149,7 +211,16 @@ class data_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf, file_offset):
+    offset: int
+    compr_len: int
+    errors: list[str]
+
+    key: ParsedKey
+    size: int
+    compr_type: int
+    plaintext_size: int
+
+    def __init__(self, buf: bytes, file_offset: int) -> None:
 
         fields = dict(list(zip(UBIFS_DATA_NODE_FIELDS, struct.unpack(UBIFS_DATA_NODE_FORMAT, buf[0:UBIFS_DATA_NODE_SZ]))))
         for key in fields:
@@ -162,15 +233,15 @@ class data_node(object):
         setattr(self, 'compr_len', (len(buf) - UBIFS_DATA_NODE_SZ))
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Data Node'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.data_node(self, tab)
 
 
@@ -182,7 +253,13 @@ class idx_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf):
+    branches: list[branch]
+    errors: list[int]
+
+    child_cnt: int
+    level: int
+
+    def __init__(self, buf: bytes) -> None:
         fields = dict(list(zip(UBIFS_IDX_NODE_FIELDS, struct.unpack(UBIFS_IDX_NODE_FORMAT, buf[0:UBIFS_IDX_NODE_SZ]))))
         for key in fields:
             setattr(self, key, fields[key])
@@ -194,15 +271,15 @@ class idx_node(object):
         setattr(self, 'branches', [branch(buf[idxs+(brs*i):idxs+(brs*i)+brs]) for i in range(0, self.child_cnt)])
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Index Node'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.idx_node(self, tab)
 
 
@@ -212,7 +289,15 @@ class branch(object):
     Arguments:
     Bin:buf     -- Raw data to extract header information from.
     """
-    def __init__(self, buf):
+    hash: bytes
+    errors: list[str]
+
+    lnum: int
+    offs: int
+    len: int
+    key: ParsedKey
+
+    def __init__(self, buf: bytes) -> None:
         fields = dict(list(zip(UBIFS_BRANCH_FIELDS, struct.unpack(UBIFS_BRANCH_FORMAT, buf[0:UBIFS_BRANCH_SZ]))))
         for key in fields:
             if key == 'key':
@@ -225,15 +310,15 @@ class branch(object):
 
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Branch'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.branch(self, tab)
     
 
@@ -246,7 +331,39 @@ class sb_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf, file_offset=-1):
+    errors: list[str]
+
+    padding: bytes
+    key_hash: int
+    key_fmt: int
+    flags: int
+    min_io_size: int
+    leb_size: int
+    leb_cnt: int
+    max_leb_cnt: int
+    max_bud_bytes: int
+    log_lebs: int
+    lpt_lebs: int
+    orph_lebs: int
+    jhead_cnt: int
+    fanout: int
+    lsave_cnt: int
+    fmt_version: int
+    default_compr: int
+    padding1: bytes
+    rp_uid: int
+    rp_gid: int
+    rp_size: int
+    time_gran: int
+    uuid: bytes
+    ro_compat_version: int
+    hmac: bytes
+    hmac_wkm: bytes
+    hash_algo: int
+    hash_mst: bytes
+    padding2: bytes
+
+    def __init__(self, buf: bytes, file_offset: int = -1) -> None:
         self.file_offset = file_offset
         fields = dict(list(zip(UBIFS_SB_NODE_FIELDS, struct.unpack(UBIFS_SB_NODE_FORMAT, buf))))
         for key in fields:
@@ -254,15 +371,15 @@ class sb_node(object):
 
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Super Block Node'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.sb_node(self, tab)
 
 
@@ -275,7 +392,42 @@ class mst_node(object):
 
     See ubifs/defines.py for object attributes.
     """
-    def __init__(self, buf, file_offset=-1):
+    errors: list[str]
+
+    highest_inum: int
+    cmt_no: int
+    flags: int
+    log_lnum: int
+    root_lnum: int
+    root_offs: int
+    root_len: int
+    gc_lnum: int
+    ihead_lnum: int
+    ihead_offs: int
+    index_size: int
+    total_free: int
+    total_dirty: int
+    total_used: int
+    total_dead: int
+    total_dark: int
+    lpt_lnum: int
+    lpt_offs: int
+    nhead_lnum: int
+    nhead_offs: int
+    ltab_lnum: int
+    ltab_offs: int
+    lsave_lnum: int
+    lsave_offs: int
+    lscan_lnum: int
+    empty_lebs: int
+    idx_lebs: int
+    leb_cnt: int
+    hash_root_idx: int
+    hash_lpt: bytes
+    hmac: bytes
+    padding: bytes
+
+    def __init__(self, buf: bytes, file_offset: int = -1) -> None:
         self.file_offset = file_offset
         fields = dict(list(zip(UBIFS_MST_NODE_FIELDS, struct.unpack(UBIFS_MST_NODE_FORMAT, buf))))
         for key in fields:
@@ -283,13 +435,13 @@ class mst_node(object):
 
         setattr(self, 'errors', [])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UBIFS Master Block Node'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         for key in dir(self):
             if not key.startswith('_'):
                 yield key, getattr(self, key)
 
-    def display(self, tab=''):
+    def display(self, tab: str = '') -> str:
         return display.mst_node(self, tab)

--- a/ubireader/ubifs/output.py
+++ b/ubireader/ubifs/output.py
@@ -17,8 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
 import os
 import struct
+from typing import TYPE_CHECKING
 
 from ubireader.ubifs.decrypt import decrypt_symlink_target
 from ubireader import settings
@@ -27,13 +29,18 @@ from ubireader.ubifs import walk
 from ubireader.ubifs.misc import process_reg_file
 from ubireader.debug import error, log, verbose_log
 
-def is_safe_path(basedir, path):
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from ubireader.ubifs import ubifs as Ubifs, nodes
+    from ubireader.ubifs.walk import Inode
+
+def is_safe_path(basedir: str, path: str) -> bool:
     basedir = os.path.realpath(basedir)
     path = os.path.realpath(os.path.join(basedir, path))
     return True if path.startswith(basedir) else False
 
 
-def extract_files(ubifs, out_path, perms=False):
+def extract_files(ubifs: Ubifs, out_path: str, perms: bool = False) -> None:
     """Extract UBIFS contents to_path/
 
     Arguments:
@@ -41,8 +48,8 @@ def extract_files(ubifs, out_path, perms=False):
     Str:out_path  -- Path to extract contents to.
     """
     try:
-        inodes = {}
-        bad_blocks = []
+        inodes: dict[int, Inode] = {}
+        bad_blocks: list[int] = []
 
         walk.index(ubifs, ubifs.master_node.root_lnum, ubifs.master_node.root_offs, inodes, bad_blocks)
 
@@ -59,7 +66,7 @@ def extract_files(ubifs, out_path, perms=False):
         error(extract_files, 'Error', '%s' % e)
 
 
-def extract_dents(ubifs, inodes, dent_node, path='', perms=False):
+def extract_dents(ubifs: Ubifs, inodes: Mapping[int, Inode], dent_node: nodes.dent_node, path: str = '', perms: bool = False) -> None:
     if dent_node.inum not in inodes:
         error(extract_dents, 'Error', 'inum: %s not found in inodes' % (dent_node.inum))
         return

--- a/ubireader/ubifs/walk.py
+++ b/ubireader/ubifs/walk.py
@@ -17,13 +17,26 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, TypedDict
 from ubireader import settings
 from ubireader.ubifs import nodes
 from ubireader.ubifs.defines import *
 from ubireader.debug import error, log, verbose_log, verbose_display
 from ubireader.ubifs.decrypt import decrypt_filenames
 
-def index(ubifs, lnum, offset, inodes={}, bad_blocks=[]):
+if TYPE_CHECKING:
+    from ubireader.ubifs import ubifs as Ubifs
+
+class Inode(TypedDict, total=False):
+    ino: nodes.ino_node
+    data: list[nodes.data_node]
+    dent: list[nodes.dent_node]
+    xent: list[nodes.xent_node]
+    hlink: str
+
+def index(ubifs: Ubifs, lnum: int, offset: int, inodes: MutableMapping[int, Inode] = {}, bad_blocks: list[int] = []) -> None:
     """Walk the index gathering Inode, Dir Entry, and File nodes.
 
     Arguments:
@@ -42,7 +55,7 @@ def index(ubifs, lnum, offset, inodes={}, bad_blocks=[]):
     _index(ubifs, lnum, offset, inodes, bad_blocks)
     decrypt_filenames(ubifs, inodes)
 
-def _index(ubifs, lnum, offset, inodes={}, bad_blocks=[]):
+def _index(ubifs: Ubifs, lnum: int, offset: int, inodes: MutableMapping[int, Inode] = {}, bad_blocks: list[int] = []) -> None:
     """Walk the index gathering Inode, Dir Entry, and File nodes.
 
     Arguments:

--- a/ubireader/utils.py
+++ b/ubireader/utils.py
@@ -17,13 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
+from __future__ import annotations
 import re
 from ubireader.debug import error, log
 from ubireader.ubi.defines import UBI_EC_HDR_MAGIC, FILE_CHUNK_SZ
 from ubireader.ubifs.defines import UBIFS_NODE_MAGIC, UBIFS_SB_NODE_SZ, UBIFS_SB_NODE, UBIFS_COMMON_HDR_SZ
 from ubireader.ubifs import nodes
 
-def guess_start_offset(path, guess_offset=0):
+def guess_start_offset(path: str, guess_offset: int =0) -> int | None:
     file_offset = guess_offset
 
     f = open(path, 'rb')
@@ -60,7 +61,7 @@ def guess_start_offset(path, guess_offset=0):
     f.close()
 
 
-def guess_filetype(path, start_offset=0):
+def guess_filetype(path: str, start_offset: int = 0) -> bytes | None:
     log(guess_filetype, 'Looking for file type at %s' % start_offset)
 
     with open(path, 'rb') as f:
@@ -81,7 +82,7 @@ def guess_filetype(path, start_offset=0):
     return ftype
 
 
-def guess_leb_size(path):
+def guess_leb_size(path: str) -> int | None:
     """Get LEB size from superblock
 
     Arguments:
@@ -125,7 +126,7 @@ def guess_leb_size(path):
     return block_size
 
 
-def guess_peb_size(path):
+def guess_peb_size(path: str) -> int | None:
     """Determine the most likely block size
 
     Arguments:
@@ -138,7 +139,7 @@ def guess_peb_size(path):
         common length between them.
     """
     file_offset = 0
-    offsets = []
+    offsets: list[int] = []
     f = open(path, 'rb')
     f.seek(0,2)
     file_size = f.tell()+1
@@ -160,7 +161,7 @@ def guess_peb_size(path):
         file_offset += FILE_CHUNK_SZ
     f.close()
 
-    occurrences = {}
+    occurrences: dict[int, int] = {}
     for i in range(0, len(offsets)):
         try:
             diff = offsets[i] - offsets[i-1]


### PR DESCRIPTION
This PR adds type hints to the codebase without making any other changes.
There are a few type errors that get picked up by the likes of `mypy`, `ty`, `pyright`, but resolving those requires changes to the code, which I wanted to avoid in this PR.

I tested the scripts with Python 3.9 (the min version as per the project.toml) to verify it still works.